### PR TITLE
fix(firebase): Realtime database URL 수정 및 env 추가

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -5,6 +5,7 @@ const storageBucket = import.meta.env.VITE_FIRBASE_STORAGE_BUCKTET;
 const messagingSenderId = import.meta.env.VITE_FIRBASE_MESSAGE_SENDER_ID;
 const appId = import.meta.env.VITE_FIRBASE_APP_ID;
 const measurementId = import.meta.env.VITE_FIRBASE_MEASUREMENT_ID;
+const databaseURL = import.meta.env.VITE_FIRBASE_DATABASE_URL;
 
 export const firebaseSettings = {
   apiKey,
@@ -15,4 +16,5 @@ export const firebaseSettings = {
   messagingSenderId,
   measurementId,
   appId,
+  databaseURL,
 };

--- a/config/firbaseConfig.js
+++ b/config/firbaseConfig.js
@@ -2,7 +2,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAnalytics } from 'firebase/analytics';
 import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import { getDatabase } from 'firebase/database'; // realtime database 초기화
 import { firebaseSettings } from './env';
 
 // TODO: Add SDKs for Firebase products that you want to use
@@ -18,10 +18,10 @@ const firebaseConfig = {
   messagingSenderId: firebaseSettings.messagingSenderId,
   appId: firebaseSettings.appId,
   measurementId: firebaseSettings.measurementId,
+  databaseURL: firebaseSettings.databaseURL,
 };
-
 // Initialize Firebase
 export const app = initializeApp(firebaseConfig);
 export const analytics = getAnalytics(app);
-export const db = getFirestore(app);
+export const db = getDatabase(app);  // app 인스턴스를 전달하여 올바르게 초기화
 export const auth = getAuth(app);

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -29,7 +29,7 @@ export default function Header() {
             filled='outline'
             disabled={false}
             onClick={() => {
-              navigate('/auth');
+              navigate('/auth/login');
             }}>
             로그인
           </Button>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -20,6 +20,7 @@ export default function Header() {
             disabled={false}
             onClick={() => {
               logout();
+              navigate('/');
             }}>
             로그아웃
           </Button>

--- a/src/features/Login/__tests__/AddUser.test.js
+++ b/src/features/Login/__tests__/AddUser.test.js
@@ -1,8 +1,111 @@
-import { describe, expect } from 'vitest';
-import { auth } from '../../../../config/firbaseConfig';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
 
+// Firebase 모듈들을 모킹(mocking)하여 실제 Firebase 서비스 대신 가짜 함수들을 사용
+// 이렇게 하면 테스트 시 실제 Firebase에 연결하지 않고도 테스트를 실행할 수 있음
+
+// Firebase Auth 모듈 모킹
+vi.mock('firebase/auth', () => ({
+  createUserWithEmailAndPassword: vi.fn(), // 회원가입 함수를 가짜 함수로 대체
+  getAuth: vi.fn(() => ({})), // 인증 객체를 가짜 객체로 대체
+}));
+
+// Firebase Realtime Database 모듈 모킹
+vi.mock('firebase/database', () => ({
+  ref: vi.fn(), // 데이터베이스 참조 생성 함수를 가짜 함수로 대체
+  set: vi.fn(), // 데이터 저장 함수를 가짜 함수로 대체
+}));
+
+// Firebase 설정 파일 모킹
+vi.mock('../../../../config/firbaseConfig', () => ({
+  db: {
+    _checkNotDeleted: vi.fn(), // Firebase 내부 검증 함수를 가짜 함수로 대체
+  },
+  auth: {}, // 인증 객체를 빈 객체로 대체
+}));
+
+// 모킹 설정 후에 실제 함수들을 import
+// 이 순서가 중요함: 모킹을 먼저 하고 import해야 함
+import { signUp, addUserStore } from '../service/authService';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { ref, set } from 'firebase/database';
+
+// 회원가입 관련 테스트 그룹
 describe('회원가입 진행 로직 테스트', () => {
-  test('auth가 잘 불러와지는지 확인해야함', () => {
-    expect(auth).toBeDefined();
+  // 각 테스트 실행 전에 모든 모킹을 초기화
+  // 이렇게 하면 각 테스트가 독립적으로 실행됨
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // 회원가입 성공 시나리오 테스트
+  test('회원가입 성공 테스트', async () => {
+    // 테스트용 가짜 사용자 데이터 설정
+    const mockUser = { uid: 'test-uid', email: 'test@test.com' };
+    
+    // Firebase Auth 함수들이 성공적으로 동작하도록 모킹
+    createUserWithEmailAndPassword.mockResolvedValue({ user: mockUser });
+    set.mockResolvedValue(); // 데이터베이스 저장도 성공하도록 설정
+
+    // 실제 회원가입 함수 호출
+    const result = await signUp({
+      username: '테스트',
+      userid: 'test@test.com',
+      password: '123456'
+    });
+
+    // 결과 검증: 성공 여부와 사용자 정보 확인
+    expect(result.success).toBe(true);
+    expect(result.user).toEqual(mockUser);
+  });
+
+  // 회원가입 실패 시나리오 테스트
+  test('회원가입 실패 테스트', async () => {
+    // Firebase Auth 함수가 에러를 발생시키도록 모킹
+    createUserWithEmailAndPassword.mockRejectedValue(new Error('회원가입 실패'));
+
+    // 실제 회원가입 함수 호출 (실패 예상)
+    const result = await signUp({
+      username: '테스트',
+      userid: 'test@test.com',
+      password: '123456'
+    });
+
+    // 결과 검증: 실패 여부와 에러 메시지 확인
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('회원가입 실패');
+  });
+
+  // Firebase Realtime Database 저장 기능 테스트
+  test('Firestore 저장 테스트', async () => {
+    // 데이터베이스 참조를 위한 가짜 객체 생성
+    const mockRef = { path: 'users/test-uid' };
+    
+    // ref 함수가 가짜 참조 객체를 반환하도록 모킹
+    ref.mockReturnValue(mockRef);
+    
+    // set 함수가 성공적으로 완료되도록 모킹
+    set.mockResolvedValue();
+
+    // 테스트용 사용자 정보
+    const userInfo = {
+      username: 'test',
+      userUid: 'test-uid',
+    };
+    
+    // 실제 데이터베이스 저장 함수 호출
+    // 함수가 에러 없이 실행되는지 확인
+    await expect(addUserStore(userInfo)).resolves.not.toThrow();
+    
+    // Firebase 함수들이 올바르게 호출되었는지 검증
+    
+    // 1. ref 함수가 올바른 경로로 호출되었는지 확인
+    // expect.anything()은 첫 번째 매개변수(db 객체)가 무엇이든 상관없다는 의미
+    expect(ref).toHaveBeenCalledWith(expect.anything(), 'users/test-uid');
+    
+    // 2. set 함수가 올바른 참조와 데이터로 호출되었는지 확인
+    expect(set).toHaveBeenCalledWith(mockRef, {
+      userUid: 'test-uid',
+      username: 'test',
+    });
   });
 });

--- a/src/features/Login/components/LoginForm.jsx
+++ b/src/features/Login/components/LoginForm.jsx
@@ -2,8 +2,16 @@ import React from 'react';
 import { useForm } from 'react-hook-form';
 import FormInput from './FormInput';
 import Button from '../../../components/Button';
+import { login } from '../service/authService';
+import { useNavigate } from 'react-router-dom';
+import useToast from '../hooks/useToast';
+import { useUserStore } from '../../../store/userStore';
 
 export default function LoginForm() {
+  const navigate = useNavigate();
+  const { isLoading } = useUserStore();
+  const { showLoading } = useToast();
+
   const {
     register,
     handleSubmit,
@@ -17,8 +25,34 @@ export default function LoginForm() {
     },
   });
 
-  const onSubmit = (data) => {
+  const onSubmit = async (data) => {
     console.log(data);
+    
+    // 로딩 시작
+    const loadingToast = showLoading('로그인 중...');
+    
+    try {
+      const result = await login(data); 
+      console.log(result);
+      
+      if(result.success === true) {
+        // 로딩 종료 및 성공 메시지
+        loadingToast.success('로그인 되었습니다!');
+        
+        // 잠시 후 메인 페이지로 이동
+        setTimeout(() => {
+          navigate('/');
+        }, 1000);
+      } else {
+        console.log(result.error);
+        // 로딩 종료 및 에러 메시지
+        loadingToast.error(result.error || '로그인에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('로그인 중 오류 발생:', error);
+      // 로딩 종료 및 에러 메시지
+      loadingToast.error('로그인 중 오류가 발생했습니다.');
+    }
   };
 
   return (
@@ -55,7 +89,7 @@ export default function LoginForm() {
             })}
           />
 
-          <Button size='full' filled='filled' disabled={false} type='submit'>
+          <Button size='full' filled='filled' disabled={isLoading} type='submit'>
             로그인
           </Button>
         </form>

--- a/src/features/Login/hooks/useToast.js
+++ b/src/features/Login/hooks/useToast.js
@@ -1,0 +1,58 @@
+// src/hooks/useToast.js
+import { toast } from 'react-hot-toast';
+
+export default function useToast(message = '성공적으로 처리되었습니다.') {
+  const showSuccess = (message) => {
+    toast.success(message, {
+      duration: 3000,
+    });
+  };
+
+  const showError = (message = '오류가 발생했습니다.') => {
+    toast.error(message, {
+      duration: 3000,
+    });
+  };
+
+  const showInfo = (message = '알림입니다.') => {
+    toast(message, {
+      duration: 3000,
+    });
+  };
+
+  // 로딩 토스트를 표시하고 Promise를 반환하는 객체를 제공하는 함수
+  const showLoading = (message = '처리 중입니다...') => {
+    const toastId = toast.loading(message); // 단순 ID 반환
+    return {
+      success: (successMessage = '성공적으로 완료되었습니다!') => {
+        toast.success(successMessage, { id: toastId });
+      },
+      error: (errorMessage = '오류가 발생했습니다.') => {
+        toast.error(errorMessage, { id: toastId });
+      },
+      dismiss: () => {
+        toast.dismiss(toastId);
+      },
+    };
+  };
+
+  // 비동기 작업(프로미스)을 toast로 감싸서 로딩/성공/실패 상태를 보여주는 함수입니다.
+  const showPromise = ({ promise, loading = '처리 중입니다...', success = '성공적으로 완료되었습니다!', error = '오류가 발생했습니다.' }) => {
+    toast.promise(
+      promise,
+      {
+        loading,
+        success,
+        error,
+      }
+    );
+  };
+
+  return {
+    showSuccess,
+    showError,
+    showInfo,
+    showLoading,
+    showPromise,
+  };
+}

--- a/src/features/Login/pages/AuthPage.jsx
+++ b/src/features/Login/pages/AuthPage.jsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
 import RegisterForm from '../components/RegisterForm';
 import LoginForm from '../components/LoginForm';
+import { NavLink, Outlet, useLocation } from 'react-router-dom';
 
 export default function AuthPage() {
-  const [isActive, setActive] = useState('LOGIN');
-
+  const location = useLocation();
+  
   const components = [
-    { page: 'LOGIN', title: '로그인', component: <LoginForm /> },
-    { page: 'SINGUP', title: '회원가입', component: <RegisterForm /> },
+    { page: 'login', title: '로그인', component: <LoginForm /> },
+    { page: 'register', title: '회원가입', component: <RegisterForm /> },
   ];
+
 
   return (
     <div className=' flex justify-center items-center p-2'>
@@ -18,25 +20,25 @@ export default function AuthPage() {
           <ul className='flex justify-center items-center gap-8 mt-5'>
             {components.map((value, idx) => (
               <li key={idx}>
-                <button
-                  onClick={() => setActive(value.page)}
+                <NavLink
+                  to={`/auth/${value.page}`}
                   className={`
                 pb-2 px-1 font-medium text-xl transition-colors duration-200
                 ${
-                  isActive === value.page
-                    ? 'text-[var(--color-primary)] font-bold'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  location.pathname === `/auth/${value.page}`
+                    ? 'text-[var(--color-primary)] font-bold border-b-2 border-[var(--color-primary)]'
+                    : 'border-transparent text-gray-500 hover:text-[var(--color-primary)] hover:border-b-2 hover:border-[var(--color-primary)]'
                 }
               `}>
                   {value.title}
-                </button>
+                </NavLink>
               </li>
             ))}
           </ul>
         </div>
 
         {/* 보여지는 곳 */}
-        <div className='p-6 md:p-8'>{components.find((comp) => comp.page === isActive)?.component}</div>
+        <div className='p-6 md:p-8'><Outlet /></div>
       </div>
     </div>
   );

--- a/src/features/Login/provider/authApiProvider.js
+++ b/src/features/Login/provider/authApiProvider.js
@@ -1,0 +1,82 @@
+// feature/Login/service/authService.js API 호출
+import { createUserWithEmailAndPassword, getAuth, signInWithEmailAndPassword } from 'firebase/auth';
+import { ref, set } from 'firebase/database';
+import { db, auth } from '../../../../config/firbaseConfig';
+
+// 회원가입 로직 
+export async function registerUser({ username, userid, password }) {
+
+  try {
+    const userCredential = await createUserWithEmailAndPassword(auth, userid, password);
+    const user = userCredential.user;
+    console.log('회원가입 성공:', user);
+    return {
+      success: true,
+      user,
+    };
+  } catch (error) {
+    console.error('회원가입 실패:', error.message);
+    if(error.message === 'auth/email-already-in-use') {
+      return {
+        success: false,
+        error: '이미 존재하는 이메일입니다.',
+      };
+    }
+  }
+}
+
+// 회원가입 성공 시 파이어 스토어에 저장
+export async function addUserFirestore({ username, userUid }) {
+  console.log('Firestore에 저장할 유저 정보:', userUid, username);
+  console.log('DB 객체 확인:', db);
+  
+  try {
+    const userRef = ref(db, 'users/' + userUid);
+    console.log('생성된 참조:', userRef);
+    
+    const userData = {
+      userUid,
+      username,
+      createdAt: new Date().toISOString(),
+    };
+    console.log('저장할 데이터:', userData);
+    
+    //여기서부터 동작을 하지 않음
+    await set(userRef, userData);
+    console.log('회원가입 DB 저장 성공:', userUid);
+    
+    return {
+      success: true,
+      message: '회원가입 성공',
+    };
+  } catch (error) {
+    console.error('회원가입 DB 저장 실패:', error);
+    console.error('에러 코드:', error.code);
+    console.error('에러 메시지:', error.message);
+    
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+}
+
+// 로그인 로직
+export async function loginUser({ userid, password }) {
+  const auth = getAuth();
+  try {
+    const userCredential = await signInWithEmailAndPassword(auth, userid, password);
+    const user = userCredential.user;
+    console.log('로그인 성공:', user);
+    return {
+      success: true,
+      user,
+    };
+  } catch (error) {
+    console.error('로그인 실패:', error);
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+} 

--- a/src/features/Login/service/authService.js
+++ b/src/features/Login/service/authService.js
@@ -1,0 +1,31 @@
+// feature/Login/service/authService.js API 호출 추상화
+import { registerUser, addUserFirestore, loginUser } from '../provider/authApiProvider';
+import { useUserStore } from '../../../store/userStore';
+
+export const signUp = async (userInfo) => {
+  const { username, userid, password } = userInfo;
+  useUserStore.getState().setLoading(true);
+  const result = await registerUser({ username, userid, password });
+  useUserStore.getState().setLoading(false);
+  return result;
+};
+
+// 회원정보 realtime database에 저장
+export const addUserStore = async (userInfo) => {
+  useUserStore.getState().setLoading(true);
+  const result = await addUserFirestore(userInfo);
+  useUserStore.getState().setLoading(false);
+  return result;
+};
+
+// 로그인 로직 호출
+export const login = async (userInfo) => {
+  const { userid, password } = userInfo;
+  useUserStore.getState().setLoading(true);
+  const result = await loginUser({ userid, password });
+  if(result.success === true) {
+    useUserStore.getState().setUser(result.user);
+  }
+  useUserStore.getState().setLoading(false);
+  return result;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,6 +10,8 @@ import MainPage from './features/Main/MainPage.jsx';
 import TimerPage from './features/Time/TimerPage.jsx';
 import AuthPage from './features/Login/pages/AuthPage.jsx';
 import ForgotPasswordPage from './features/login/pages/ForgotPasswordPage.jsx';
+import LoginForm from './features/Login/components/LoginForm.jsx';
+import RegisterForm from './features/Login/components/RegisterForm.jsx';
 
 const router = createBrowserRouter([
   {
@@ -23,7 +25,12 @@ const router = createBrowserRouter([
       {
         path: '/auth',
         element: <AuthPage />,
-        children: [{ path: 'forgot-password', element: <ForgotPasswordPage /> }],
+        children: [
+          { index: true, element: <LoginForm /> },
+          { path: 'forgot-password', element: <ForgotPasswordPage /> },
+          { path: 'login', element: <LoginForm /> },
+          { path: 'register', element: <RegisterForm /> },
+        ],
       },
       {
         path: '/timer', // 경로 수정 가능

--- a/src/store/userStore.js
+++ b/src/store/userStore.js
@@ -2,12 +2,14 @@ import { create } from 'zustand';
 
 const useUserStore = create((set) => ({
   userInfo: {
-    id: '',
-    name: '',
+    userUid: '',
+    username: '',
   },
   isAuthenticated: false, // 로그인 상태 관리
+  isLoading: false, // 로딩 상태 관리
   setUser: (userInfo) => set({ userInfo, isAuthenticated: true }), // 로그인 성공 시 호출
   logout: () => set({ userInfo: {}, isAuthenticated: false }), // 로그아웃
+  setLoading: (isLoading) => set({ isLoading }), // 로딩 상태 관리
 }));
 
 export { useUserStore };


### PR DESCRIPTION
## 변경 내용
- Firebase Realtime Database URL을 `asia-southeast1` 리전에 맞게 수정했습니다.
    - Firebase Realtime Database URL을 추가했습니다.
- 기존 URL (`https://pasta-pomatoma-default-rtdb.firebaseio.com/`)은 리전이 맞지 않아 **데이터 쓰기 작업이 무시되거나 실패하는 이슈**가 있었습니다.
- _로그인과 회원가입 라우터를 추가했습니다._

## 원인
- Firebase 프로젝트의 실제 DB 리전은 `asia-southeast1`로 설정되어 있었으나, 코드상에서는 기본 리전(`.firebaseio.com`)을 사용하고 있었습니다.
- 이로 인해 다음과 같은 경고 메시지가 발생하며 데이터 저장이 되지 않았습니다:
  > FIREBASE WARNING: Database lives in a different region.

## 변경 이유
- DB 동작이 정상적으로 이뤄지지 않아, 실시간 데이터 쓰기 작업이 동작하도록 올바른 URL로 설정을 변경했습니다.
- `.env` 및 Firebase 설정(config) 파일에서 URL을 수정했습니다.

## 확인 방법
- 회원가입 후 Realtime Database에 사용자 정보가 정상적으로 저장되는지 확인합니다.
- 콘솔에 더 이상 경고 메시지가 발생하지 않아야 합니다.
<img width="946" height="316" alt="스크린샷 2025-08-06 오후 1 11 25" src="https://github.com/user-attachments/assets/7aed49c5-ea2c-4e6f-bb56-14323806a23c" />
<img width="675" height="589" alt="스크린샷 2025-08-06 오후 1 11 31" src="https://github.com/user-attachments/assets/121e7caf-aa79-4e9a-998b-49cdf42d79f2" />

## 관련 이슈
- 사용자 정보 저장이 실패하던 문제 해결

---

