### PR TITLE
Fix: Toast 알람 안뜨는 이슈 해결

### DIFF
--- a/src/features/Login/components/RegisterForm.jsx
+++ b/src/features/Login/components/RegisterForm.jsx
@@ -3,7 +3,6 @@ import FormInput from './FormInput';
 import { useForm } from 'react-hook-form';
 import Button from '../../../components/Button';
 import { signUp, addUserStore } from '../service/authService';
-// import { setActive } from '../pages/AuthPage';
 import { useNavigate } from 'react-router-dom';
 import useToast from '../hooks/useToast';
 import { useUserStore } from '../../../store/userStore';
@@ -29,15 +28,11 @@ export default function RegisterForm() {
   const { showLoading } = useToast();
   const { isLoading } = useUserStore();
   const onSubmit = async (data) => {
-    console.log('회원가입 시작!');
-    
     // 로딩 시작
     const loadingToast = showLoading('회원가입 중...');
     
     try {
-      const result = await signUp(data);
-      console.log(result.user.uid);
-      
+      const result = await signUp(data);      
       // 만약 회원이 생성되었을 경우
       if(result.success === true) {
         // 회원 정보를 realtime database에 저장

--- a/src/features/Login/pages/AuthPage.jsx
+++ b/src/features/Login/pages/AuthPage.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import RegisterForm from '../components/RegisterForm';
 import LoginForm from '../components/LoginForm';
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
+import { Toaster } from 'react-hot-toast';
 
 export default function AuthPage() {
   const location = useLocation();
@@ -40,6 +41,7 @@ export default function AuthPage() {
         {/* 보여지는 곳 */}
         <div className='p-6 md:p-8'><Outlet /></div>
       </div>
+      <Toaster position='top-center' />
     </div>
   );
 }


### PR DESCRIPTION
## 📝 PR 제목

> Fix: Toast 알람이 표시되지 않는 이슈 해결

## 🔍 문제 상황
- 로그인 및 회원가입 등의 이벤트 진행 후, 아무 알람창이 뜨지 않음

## 🛠 원인 분석
- `<Toaster />` 미호출로 인해 Toast 알람 모달이 생성되지 않음

## ✅ 해결 방안
- [AuthPage.jsx](src/features/Login/pages/AuthPage.jsx) 에 `<Toaster position='top-center'>` 추가

## 🧪 테스트 완료 항목
- [x] 성공 메시지 Toast 표시 확인
- [x] 에러 메시지 Toast 표시 확인
- [x] 로딩 Toast 표시 확인