### PR TITLE
fix: 날짜 변경 시 dailyCount 초기화 및 자정 스케줄 개선

### DIFF
--- a/src/store/useTimerStore.js
+++ b/src/store/useTimerStore.js
@@ -12,14 +12,23 @@ export const useTimerStore = create(set => ({
 
   // 카운트된 값 저장
   dailyCount: 0,              // 오늘 완료된 사이클 수  
-  incrementDaily: () => // 완료될 때마다 증가
+  lastDateKey: null,
+
+  incrementDaily: () =>       // 오늘 사이클 횟수 증가
     set(state => ({
       dailyCount: state.dailyCount + 1
     })),
+
   resetDaily: () => 
-    set({dailyCount: 0}),     // 매일 자정 값 전송 후 0으로 초기화
+    set({dailyCount: 0}),    // 매일 자정 값 전송 후 0으로 초기화
+
   setDailyCount: (count) =>
      set({
       dailyCount: count
+    }),
+
+  setLastDateKey: (dateKey) => // 날짜 변경시 업데이트
+    set({
+      lastDateKey: dateKey
     }),
 }));


### PR DESCRIPTION
## 📝 변경 내용
- 날짜 변경 감지 로직 추가
- 초기 데이터 세팅 로직 통합
---
## 🔎 상세 내용
- 앱을 켜둔 상태에서 날짜가 지나면 `lastDateKey`와 `todayKey` 비교 후 `dailyCount` 초기화
- 첫 실행 시 Firebase에서 오늘 날짜의 count 가져오기 (없으면 0 생성), `lastDateKey` 갱신
---
## 📌 변경 이유
- 문제 : 앱을 켜둔 상태로 자정 지나 다시 사용할 경우 기존 날짜의 count가 이어지는 문제
- 해결 : 날짜 변경 시점에 초기화 로직 추가하여 항상 당일 기준 count를 사용하도록 변경
- 추가 : 자정 스케줄과 앱 실행 시점 모두에서 날짜 검증
---
## ✅ 영향 범위
- `useTimer` 훅 내부 로직
- `useTimerStore` 의 `lastDateKey` / `resetDaily`/ `dailyCount` 관련 데이터 흐름
- 외부 UI 컴포넌트는 변경 없음